### PR TITLE
Added in filequeue module for large file pushes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "commander": ">=2.5.1",
+    "filequeue": "^0.5.0",
     "glob": ">=4.3.2",
     "nconf": ">=0.7.1",
     "prompt": ">=0.2.14",
@@ -30,7 +31,13 @@
   },
   "author": "yyconn <conn@conn.jp>",
   "contributors": [
-    { "name": "Daniel Fried", "email": "daniel.fried@pandorabots.com" },
-    { "name": "Tina Coles", "email": "tina.coles@pandorabots.com" }
+    {
+      "name": "Daniel Fried",
+      "email": "daniel.fried@pandorabots.com"
+    },
+    {
+      "name": "Tina Coles",
+      "email": "tina.coles@pandorabots.com"
+    }
   ]
 }

--- a/pb-cli.js
+++ b/pb-cli.js
@@ -12,7 +12,7 @@ var qs = require('querystring');
 var request = require('request');
 var unzip = require('unzip');
 var url = require('url');
-var Filequeue = require('fq');
+var Filequeue = require('filequeue');
 
 var fq = new Filequeue(500);
 

--- a/pb-cli.js
+++ b/pb-cli.js
@@ -12,6 +12,9 @@ var qs = require('querystring');
 var request = require('request');
 var unzip = require('unzip');
 var url = require('url');
+var Filequeue = require('fq');
+
+var fq = new Filequeue(500);
 
 var config = 'chatbot.json';
 
@@ -481,7 +484,8 @@ else if (program.args[0] === 'push') {
     if (files.length) {
 	files.forEach (function (entry) {
 	    console.log('uploading: ' + entry);
-	    fs.createReadStream(entry).pipe(request.put(fileUri(entry), okResp));
+	    fq.createReadStream(entry).pipe(request.put(fileUri(entry), okResp));
+            
 	});
     }
     else {


### PR DESCRIPTION
TC encountered a problem when a large number of files (+1000) are pushed, in that the operating system only allows a certain number of files to be open at any given time. 

This is a problem for the `push` command, because the filestreams are created asynchronously. Node will try to open all the filestreams at the same time, and receives an error from the OS.

Solution: I added the filequeue module from NPM, which allows you to create file streams asynchronously, while setting a limit to the number of open streams in a given context. If node tries to open more than this number of files, it will queue up those requests, and make them as previous requests are completed.
